### PR TITLE
add missing round()

### DIFF
--- a/src/pystitch/Vp3Writer.py
+++ b/src/pystitch/Vp3Writer.py
@@ -256,7 +256,7 @@ def write_stitches_block(f: BinaryIO, stitches, first_pos_x, first_pos_y):
             # It moves to the relevant location without needing to block the needlebar.
             continue
         dx = int(round(x - last_x))
-        dy = int((y - last_y))
+        dy = int(round(y - last_y))
         last_x += dx
         last_y += dy
         if flags == STITCH:


### PR DESCRIPTION
I mistakenly removed one `round()` call when rebasing on embroidepy/pyembroidery a few years back.  Deeper explanation in https://github.com/inkstitch/pystitch/issues/99#issuecomment-3211903772.

fixes #99 